### PR TITLE
Update web-workers.mdx to refer to the bundling that webpack does

### DIFF
--- a/src/content/guides/web-workers.mdx
+++ b/src/content/guides/web-workers.mdx
@@ -13,7 +13,7 @@ As of webpack 5, you can use [Web Workers](https://developer.mozilla.org/en-US/d
 new Worker(new URL('./worker.js', import.meta.url));
 ```
 
-The syntax was chosen to allow running code without bundler, it is also available in native ECMAScript modules in the browser.
+The syntax was chosen to allow running code without bundler since using this is available in native ECMAScript modules in the browser (https://developer.mozilla.org/en-US/docs/Web/API/Worker/Worker). In webpack, the worker.js inside the "new Worker" API call and the files that worker.js imports are additionally bundled.
 
 ## Example
 
@@ -33,12 +33,25 @@ worker.onmessage = ({ data: { answer } }) => {
 **src/deep-thought.js**
 
 ```js
+
+import { getAnswer } from './answer'
 self.onmessage = ({ data: { question } }) => {
   self.postMessage({
-    answer: 42,
+    answer: getAnswer(),
   });
 };
 ```
+
+**src/answer.js**
+
+```js
+
+export default getAnswer() {
+  return 42
+}
+```
+
+In this case, deep-thought.js and answer.js will be bundled for use in the web worker.
 
 ## Node.js
 


### PR DESCRIPTION
I was a little confused when reading the web workers document and have returned to it a couple times and only when i tried it out mysef to see that bundling happens with the "new Worker" usage was I aware that webpack does bundling with this, so I thought I'd add some notes about this to the docs!

Let me know if this makes sense